### PR TITLE
Fix: broadcast create transaction

### DIFF
--- a/src/periphery/forge/index.ts
+++ b/src/periphery/forge/index.ts
@@ -12,6 +12,5 @@ export async function deployContract({
     .cwd(cwd)
     .json()
   core.info(`Deployed spell ${contractName} to address ${result.deployedTo}`)
-  core.debug(`Deploy result: ${result}`)
   return result.deployedTo
 }

--- a/src/periphery/forge/index.ts
+++ b/src/periphery/forge/index.ts
@@ -1,3 +1,4 @@
+import core from '@actions/core'
 import { $ } from 'dax-sh'
 import { Address } from 'viem'
 
@@ -8,5 +9,7 @@ export async function deployContract({
   cwd,
 }: { contractName: string; rpc: string; from: Address; cwd: string }): Promise<Address> {
   const result = await $`forge create --rpc-url ${rpc} --from ${from} ${contractName} --unlocked --json`.cwd(cwd).json()
+  core.info(`Deployed spell ${contractName} to address ${result.deployedTo}`)
+  core.debug(`Deploy result: ${result}`)
   return result.deployedTo
 }

--- a/src/periphery/forge/index.ts
+++ b/src/periphery/forge/index.ts
@@ -8,7 +8,9 @@ export async function deployContract({
   from,
   cwd,
 }: { contractName: string; rpc: string; from: Address; cwd: string }): Promise<Address> {
-  const result = await $`forge create --rpc-url ${rpc} --from ${from} ${contractName} --unlocked --json`.cwd(cwd).json()
+  const result = await $`forge create  --broadcast --rpc-url ${rpc} --from ${from} ${contractName} --unlocked --json`
+    .cwd(cwd)
+    .json()
   core.info(`Deployed spell ${contractName} to address ${result.deployedTo}`)
   core.debug(`Deploy result: ${result}`)
   return result.deployedTo


### PR DESCRIPTION
foundry pushed a breaking change adding the `--broadcast` flag to  `forge create`, making a dry run the default

logging should make it more evident if something like this happens in the future, but I'm open to removing it